### PR TITLE
Added basic proxmark3 client functionality

### DIFF
--- a/pm3
+++ b/pm3
@@ -1,0 +1,21 @@
+---
+syntax: bash
+tags: [ proxmark ]
+---
+# To launch the proxmark3 client with an automatically guessed port:
+pm3
+
+# To list available ports:
+pm3 --list
+
+# To connect a numbered port from the list:
+pm3 -n <N>
+
+# To connect to a specified port:
+pm3 -p /dev/ttyACM0
+
+# To start proxmark3 offline:
+pm3 -o
+
+# To forward proxmark3 help through pm3:
+pm3 -hh

--- a/proot-distro
+++ b/proot-distro
@@ -1,0 +1,20 @@
+---
+syntax: bash
+tags: [ termux, proxmark ]
+---
+# To install the proot-distro package in Termux:
+pkg install proot-distro
+
+# To install the debain proot-distro:
+proot-distro install debian
+
+# To login to the debian proot-distro:
+proot-distro login debian --termux-home
+
+# Run these commands to compile the fullimage.elf on Termux:
+proot-distro login debian --termux-home
+apt update && apt full-upgrade
+apt get install -y --no-install-recommends make gcc g++ libc6-dev gcc-arm-none-eabi libnewlib-dev
+cd proxmark3
+make -j fullimage
+exit

--- a/proxmark3
+++ b/proxmark3
@@ -1,0 +1,20 @@
+---
+syntax: bash
+tags: [ security, proxmark, nfc, rfid, cryptography ]
+---
+# To launch the proxmark3 client on Termux using TCPUART on localhost port 1234:
+proxmark3 tcp:localhost:1234
+
+# To launch the proxmark3 client on Linux and WSL:
+# Note: WSL relies on usbipd, see `cheat usbipd`
+proxmark3 /dev/ttyACM0
+
+# To launch the proxmark3 client offline:
+proxmark3
+
+# To flash a compiled fullimage.elf to the proxmark from Termux using TCPUART on localhost port 1234:
+# Note: to compile the fullimage.elf on Termux see `cheat proot-distro`
+proxmark3 tcp:localhost:1234 --flash --image armsrc/obj/fullimage.elf
+
+# To flash a compiled fullimage.elf and bootrom.elf to the proxmark from Linux:
+proxmark3 /dev/ttyACM0 --flash --unlock-bootloader --image bootrom.elf --image fullimage.elf

--- a/usbipd
+++ b/usbipd
@@ -1,0 +1,13 @@
+---
+syntax: PowerShell
+tags: [ networking, wsl, virtualization, proxmark ]
+---
+# To install usbipd:
+winget install usbipd
+
+# To list currently attached devices:
+usbipd list
+
+# To attach a device to a kali-linux WSL instance:
+# Note: This may require you to run `sudo udevadm trigger --action=change` within WSL.
+usbipd wsl attach --hardware-id XXXX:XXXX --distribution kali-linux --auto-attach


### PR DESCRIPTION
This adds commands related to the proxmark3 client on Termux, WSL and Linux, along with programs that are needed by these platforms to function (i.e. `usbipd` and `proot-distro`).